### PR TITLE
Wire editor panel to show SDL source for selected design

### DIFF
--- a/web/src/pages/CanvasViewerPage/CanvasViewerPageDockView.ts
+++ b/web/src/pages/CanvasViewerPage/CanvasViewerPageDockView.ts
@@ -297,12 +297,21 @@ export class CanvasViewerPageDockView extends CanvasViewerPageBase {
     /** Called when user selects a different design from the dropdown */
     private async onDesignSelected(systemName: string): Promise<void> {
         console.log(`[CanvasViewerPageDockView] Switching to design: ${systemName}`);
+
+        // Open the SDL source in the editor
+        const textarea = document.querySelector(`textarea.sdl-design-source[data-design="${systemName}"]`) as HTMLTextAreaElement;
+        if (textarea && this.tabbedEditor) {
+            const content = textarea.value || '';
+            const filePath = `${systemName}.sdl`;
+            await this.tabbedEditor.openFile(filePath, content, this.readonly, 'designs', systemName);
+        }
+
+        // Tell presenter to switch system — pushes diagram + generator updates
         try {
             await this.canvasViewPresenterClient.useSystem({
                 canvasId: this.currentCanvasId || 'default',
                 systemName: systemName,
             });
-            // Presenter pushes diagram + generator updates via RPC callbacks
         } catch (err) {
             console.error(`[CanvasViewerPageDockView] Failed to switch design:`, err);
         }


### PR DESCRIPTION
## Summary

When a design is selected (via dropdown or auto-select on page load), the SDL source is now shown in the Monaco editor panel. Each design gets its own editor tab.

Reads content directly from the embedded `<textarea>` elements — same source the ScriptTagFS uses for the WASM runtime.

## Test plan
- [x] `make dash` builds clean
- [x] `make webtest` — 32 passed, 1 skipped
- [x] Manual: Open Bitly workspace — editor shows Bitly SDL
- [x] Manual: Open Uber workspace — switching designs switches editor tabs